### PR TITLE
Support multi-platform builds for Docker

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,6 +32,6 @@ jobs:
         id: docker_build
         uses: docker/build-push-action@v6
         with:
-          platforms: 'linux/amd64'
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: '${{ steps.meta.outputs.tags }}'


### PR DESCRIPTION
Hi, saw a massive improv in server lag when running in mac m4 and building locally the image myself, I think you should aim to release both builds.

Docs https://docs.docker.com/build/ci/github-actions/multi-platform/