### PR TITLE
Add Java 25 CompactObjectHeader for Easy Memory Savings

### DIFF
--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -49,6 +49,9 @@ fi
 # Build the startup command
 STARTUP_CMD="java ${JVM_MEMORY}"
 
+# Add Java 25 CompactObjectHeaders for free memory savings
+STARTUP_CMD="${STARTUP_CMD} -XX:+UseCompactObjectHeaders"
+
 # Add AOT cache if enabled
 if [ "${USE_AOT_CACHE}" = "true" ] && [ -f "${SERVER_FILES}/Server/HytaleServer.aot" ]; then
     STARTUP_CMD="${STARTUP_CMD} -XX:AOTCache=${SERVER_FILES}/Server/HytaleServer.aot"


### PR DESCRIPTION
I was going to add an issue for this, but figured I can just provide the addition. I ran this locally but would love for someone with a larger world to test out the memory savings to see if it's worthwhile.

I've used JEP519 extensively in my job and can attest that I see a roughly 20-40% memory savings in most Java 25 applications.

The JEP is here: https://openjdk.org/jeps/519. There is even discussion to make it the default eventually: https://bugs.openjdk.org/browse/JDK-8360700