### PR TITLE
Add automation "auth select <AUTH_SELECT_PROFILE>" command, as well as the env var AUTH_SELECT_PROFILE

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ A Docker container for running a Hytale dedicated server with automatic download
 
 > [!IMPORTANT]
 > **First-Time Setup: Authentication Required**
-> 
+>
 > On first startup, you'll need to authenticate via your browser. The server will display a URL in the console - just visit it and log in with your Hytale account. You will then need to authorize again from the link that appears once the server has started.
 
 ## How to use
@@ -100,27 +100,28 @@ docker run -d \
 
 You can use the following values to change the settings of the server on boot.
 
-| Variable               | Default              | Description                                                                           |
-|------------------------|----------------------|---------------------------------------------------------------------------------------|
-| PUID                   | 1000                 | User ID for file permissions                                                          |
-| PGID                   | 1000                 | Group ID for file permissions                                                         |
-| SERVER_NAME            | hytale-server-docker | Name of the server                                                                    |
-| DEFAULT_PORT           | 5520                 | The port the server listens on (UDP only)                            |
-| MAX_PLAYERS            | 20                   | Maximum number of players allowed on the server                                       |
-| VIEW_DISTANCE          | 12                   | View distance in chunks (12 chunks = 384 blocks). Higher values require more RAM     |
-| AUTH_MODE              | authenticated        | Authentication mode: `authenticated` or `offline`                                     |
-| ENABLE_BACKUPS         | false                | Enable automatic world backups                                                        |
-| BACKUP_FREQUENCY       | 30                   | Backup interval in minutes (if backups are enabled)                                   |
-| BACKUP_MAX_COUNT       | 5                    | How many previous backups to retain                                                   |
-| BACKUP_DIR             | /home/hytale/server-files/backups | Directory path for storing backups                              |
-| DISABLE_SENTRY         | true                 | Disable Sentry crash reporting                                                        |
-| USE_AOT_CACHE          | true                 | Use Ahead-of-Time compilation cache for faster startup                                |
-| ACCEPT_EARLY_PLUGINS   | false                | Allow early plugins (may cause stability issues)                                      |
-| MIN_MEMORY             |                      | Minimum JVM heap size (e.g., 4G). Leave unset to omit -Xms flag                      |
-| MAX_MEMORY             | 8G                   | Maximum JVM heap size (e.g., 8G, 8192M)                                               |
-| JVM_ARGS               |                      | Custom JVM arguments (optional)                                                       |
-| PATCHLINE              | release              | Selects the patchline for the game (`release` or `pre-release`)                       |
-| DOWNLOAD_ON_START      | true                 | Automatically download/update server files on startup                                 |
+| Variable               | Default                           | Description                                                                     |
+|------------------------|-----------------------------------|---------------------------------------------------------------------------------|
+| PUID                   | 1000                              | User ID for file permissions                                                    |
+| PGID                   | 1000                              | Group ID for file permissions                                                   |
+| SERVER_NAME            | hytale-server-docker              | Name of the server                                                              |
+| DEFAULT_PORT           | 5520                              | The port the server listens on (UDP only)                                       |
+| MAX_PLAYERS            | 20                                | Maximum number of players allowed on the server                                 |
+| VIEW_DISTANCE          | 12                                | View distance in chunks (12 chunks = 384 blocks). Higher values require more RAM |
+| AUTH_MODE              | authenticated                     | Authentication mode: `authenticated` or `offline`                               |
+| ENABLE_BACKUPS         | false                             | Enable automatic world backups                                                  |
+| BACKUP_FREQUENCY       | 30                                | Backup interval in minutes (if backups are enabled)                             |
+| BACKUP_MAX_COUNT       | 5                                 | How many previous backups to retain                                             |
+| BACKUP_DIR             | /home/hytale/server-files/backups | Directory path for storing backups                                              |
+| DISABLE_SENTRY         | true                              | Disable Sentry crash reporting                                                  |
+| USE_AOT_CACHE          | true                              | Use Ahead-of-Time compilation cache for faster startup                          |
+| ACCEPT_EARLY_PLUGINS   | false                             | Allow early plugins (may cause stability issues)                                |
+| MIN_MEMORY             |                                   | Minimum JVM heap size (e.g., 4G). Leave unset to omit -Xms flag                 |
+| MAX_MEMORY             | 8G                                | Maximum JVM heap size (e.g., 8G, 8192M)                                         |
+| JVM_ARGS               |                                   | Custom JVM arguments (optional)                                                 |
+| PATCHLINE              | release                           | Selects the patchline for the game (`release` or `pre-release`)                 |
+| DOWNLOAD_ON_START      | true                              | Automatically download/update server files on startup                           |
+| AUTH_SELECT_PROFILE    | 1                                 | Sets which profile to auth the server too if multiple are linked to the account |
 
 ## Port Configuration
 

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -22,6 +22,7 @@ USE_AOT_CACHE="${USE_AOT_CACHE:-true}"
 AUTH_MODE="${AUTH_MODE:-authenticated}"
 ACCEPT_EARLY_PLUGINS="${ACCEPT_EARLY_PLUGINS:-false}"
 MAX_MEMORY="${MAX_MEMORY:-8192}"
+AUTH_SELECT_PROFILE="${AUTH_SELECT_PROFILE:-1}"
 
 # Check if HytaleServer.jar exists
 SERVER_JAR="$SERVER_FILES/Server/HytaleServer.jar"
@@ -113,7 +114,13 @@ exec 3>"$FIFO"
                 echo "/auth login device" >&3
                 LogSuccess "Sent auth command to server"
             fi
-            
+
+            if echo "$line" | grep -q "Multiple profiles available"; then
+                sleep 1
+                echo "/auth select $AUTH_SELECT_PROFILE" >&3
+                LogSuccess "Selected profile $AUTH_SELECT_PROFILE"
+            fi
+
             if echo "$line" | grep -qE "Authentication successful!|Server is already authenticated."; then
                 sleep 1
                 echo "/auth persistence Encrypted" >&3


### PR DESCRIPTION
Added env var AUTH_SELECT_PROFILE with default of 1.
AUTH_SELECT_PROFILE is used to determine which profile is signed into when an account has multiple profiles linked.
